### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install cmake ninja-build ruby
+compiler:
+  - gcc
+script:
+  - mkdir build && cd build && cmake .. -G Ninja && ninja ctest
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 enable_language(C ASM)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Test-driven development for embedded C with Unity and CTest
 
+[![Build Status](https://travis-ci.com/jonathangjertsen/tddec.svg?branch=master)](https://travis-ci.com/jonathangjertsen/tddec)
+
 ## Prerequisites
 
 * `cmake`: https://cmake.org/download/


### PR DESCRIPTION
Had to reduce cmake_minimum_required to 3.12 since that's what's bundled with Travis' default VMs (Ubuntu 16.04.6 LTS).